### PR TITLE
Readd support for tool expand.

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -2422,11 +2422,13 @@ See `font-lock-syntax-table'.")
          (bname "*Macro Expansion*")
          (buffer (get-buffer-create bname)))
     (with-current-buffer buffer
+      (read-only-mode -1)
       (erase-buffer)
       (funcall 'crystal-mode)
       (crystal-exec (list "tool" "expand" "-c"
                           (concat name ":" lineno ":" colno) name)
-                    bname))
+                    bname)
+      (read-only-mode))
     (display-buffer buffer)))
 
 (defun crystal-find-project-root ()

--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -191,7 +191,7 @@ This should only be called after matching against `crystal-here-doc-beg-re'."
     ["Indent Sexp" prog-indent-sexp
      :visible crystal-use-smie]
     "--"
-    ["Format" crystal-format t]))
+    ["Format" crystal-tool-format t]
     ["Expand macro" crystal-tool-expand t]))
 
 (defvar crystal-mode-syntax-table
@@ -2404,7 +2404,7 @@ See `font-lock-syntax-table'.")
            (append (list crystal-executable nil output-buffer-name t)
                    args))))
 
-(defun crystal-format ()
+(defun crystal-tool-format ()
   "Format the contents of the current buffer without persisting the result."
   (interactive)
   (let ((oldbuf (current-buffer))

--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -2416,16 +2416,18 @@ See `font-lock-syntax-table'.")
 (defun crystal-tool-expand ()
   "Expand macro at point."
   (interactive)
-  (let* ((name buffer-file-name)
+  (let* ((oldbuf (current-buffer))
+         (name (make-temp-file "crystal-expand" nil ".cr"))
          (lineno (number-to-string (line-number-at-pos)))
          (colno (number-to-string (+ 1 (current-column))))
          (bname "*Macro Expansion*")
          (buffer (get-buffer-create bname)))
+    (write-region nil nil name)
     (with-current-buffer buffer
       (read-only-mode -1)
       (erase-buffer)
       (funcall 'crystal-mode)
-      (crystal-exec (list "tool" "expand" "-c"
+      (crystal-exec (list "tool" "expand" "--no-color" "-c"
                           (concat name ":" lineno ":" colno) name)
                     bname)
       (read-only-mode))


### PR DESCRIPTION
Being able to expand macros are nice, and this sets the stage for implementing support for running test suite and individual specs too, even if that is not included yet. 

Hattip @hinrik for the directory finding. Perhaps the code should be shared though - I tried to make it use the same definitions but it didn't seem to work. My elisp-fu is not that great, so that is probably the reason.

Should the format and expand get shortcuts?