### PR TITLE
Make crystal tool expand work on project files. 

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -1141,7 +1141,7 @@ Special characters are `?', `$', `:' when preceded by whitespace,
 and `\\' when preceded by `?'."
   (setq pos (or pos (point)))
   (let ((c (char-before pos)) (b (and (< (point-min) pos)
-				      (char-before (1- pos)))))
+                                      (char-before (1- pos)))))
     (cond ((or (eq c ??) (eq c ?$)))
           ((and (eq c ?:) (or (not b) (eq (char-syntax b) ? ))))
           ((eq c ?\\) (eq b ??)))))
@@ -1434,7 +1434,7 @@ delimiter."
        ((looking-at "^__END__$")
         (goto-char pnt))
        ((and (looking-at crystal-here-doc-beg-re)
-	     (boundp 'crystal-indent-point))
+             (boundp 'crystal-indent-point))
         (if (re-search-forward (crystal-here-doc-end-match)
                                crystal-indent-point t)
             (forward-line 1)
@@ -1501,7 +1501,7 @@ delimiter."
                             (or (goto-char (cdr (nth 1 s))) t)))
                      (forward-word -1)
                      (setq indent (crystal-indent-size (current-column)
-						    (nth 2 state))))
+                                                    (nth 2 state))))
                     (t
                      (setq indent (current-column))
                      (cond ((eq deep 'space))
@@ -1753,7 +1753,7 @@ With ARG, do it many times.  Negative ARG means move backward."
       (condition-case nil
           (while (> i 0)
             (skip-syntax-forward " ")
-	    (if (looking-at ",\\s *") (goto-char (match-end 0)))
+            (if (looking-at ",\\s *") (goto-char (match-end 0)))
             (cond ((looking-at "\\?\\(\\\\[CM]-\\)*\\\\?\\S ")
                    (goto-char (match-end 0)))
                   ((progn
@@ -1812,8 +1812,8 @@ With ARG, do it many times.  Negative ARG means move forward."
                   ((looking-at "\\s\"\\|\\\\\\S_")
                    (let ((c (char-to-string (char-before (match-end 0)))))
                      (while (and (search-backward c)
-				 (eq (logand (skip-chars-backward "\\") 1)
-				     1))))
+                                 (eq (logand (skip-chars-backward "\\") 1)
+                                     1))))
                    nil)
                   ((looking-at "\\s.\\|\\s\\")
                    (if (crystal-special-char-p) (forward-char -1)))

--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -2541,6 +2541,16 @@ See `font-lock-syntax-table'.")
   (interactive)
   (crystal-tool--location "context"))
 
+(defun crystal-tool--project-name ()
+  "Try to figure out the name of the project."
+  (let* ((default-directory (crystal-find-project-root))
+         (dirname (directory-file-name (file-relative-name default-directory "..")))
+         (project-name (concat (file-name-as-directory "src") (concat dirname ".cr")))
+         (full-project (concat default-directory project-name) ))
+    (if (file-exists-p full-project)
+        project-name
+      "")))
+
 (defun crystal-tool--location(sub-cmd &optional crystal-mode-p)
   (let* ((name (or
                 (and (file-exists-p buffer-file-name) buffer-file-name)
@@ -2557,7 +2567,7 @@ See `font-lock-syntax-table'.")
       (when crystal-mode-p
         (funcall 'crystal-mode)))
       (crystal-exec (list "tool" sub-cmd "--no-color" "-c"
-                          (concat name ":" lineno ":" colno) name)
+                          (concat name ":" lineno ":" colno) name (crystal-tool--project-name))
                     bname)
       (with-current-buffer buffer
         (when (string-equal sub-cmd "implementations")
@@ -2595,7 +2605,7 @@ description at POINT."
                          "tool" "implementations"
                          "--no-color"
                          "-f" "json"
-                         "-c" (concat fname ":" lineno ":" colno) fname)
+                         "-c" (concat fname ":" lineno ":" colno) fname (crystal-tool--project-name))
                         outbuf)
           (let* ((imp-res-str (with-current-buffer outbuf (buffer-string)))
                  (imp-res-json (let ((json-key-type 'string))

--- a/flycheck-crystal.el
+++ b/flycheck-crystal.el
@@ -57,7 +57,7 @@ of the current file."
    (and
     buffer-file-name
     (locate-dominating-file buffer-file-name "shard.yml"))
-default-directory))
+   default-directory))
 
 (flycheck-define-checker crystal-build
   "A Crystal syntax checker using crystal build"
@@ -66,7 +66,9 @@ default-directory))
             "--no-codegen"
             "--no-color"
             "-f" "json"
-            source-inplace)
+            source-inplace
+            (eval (crystal-tool--project-name))
+            )
   :working-directory flycheck-crystal--find-default-directory
   :error-parser flycheck-crystal--error-parser
   :modes crystal-mode


### PR DESCRIPTION
I did a quick attempt at the flycheck mode too (which would need a very similar fix), but didn't manage to do it the seemingly obvious way.

It would have been nice to be able to get a proper list of compile targets somehow :/

EDIT: Figured out how to make flycheck happy.