### PR TITLE
Fix use of `flycheck-crystal-show-instantiating`

### DIFF
--- a/flycheck-crystal.el
+++ b/flycheck-crystal.el
@@ -73,18 +73,19 @@ default-directory))
   )
 
 (defun flycheck-crystal--error-parser (output checker buffer)
-  (mapcan
-   (lambda (err)
-     (when (or flycheck-crystal-show-instantiating
-               (not (string-prefix-p "instantiating" (cdr-safe (assoc 'message err)))))
-       (list (flycheck-error-new-at (cdr-safe (assoc 'line err))
-                                    (cdr-safe (assoc 'column err))
-                                    'error
-                                    (cdr-safe (assoc 'message err))
-                                    :checker checker
-                                    :buffer buffer
-                                    :filename (cdr-safe (assoc 'file err))))))
-   (json-read-from-string output)))
+  (unless (zerop (length output))
+    (mapcan
+     (lambda (err)
+       (when (or flycheck-crystal-show-instantiating
+                 (not (string-prefix-p "instantiating" (cdr-safe (assoc 'message err)))))
+         (list (flycheck-error-new-at (cdr-safe (assoc 'line err))
+                                      (cdr-safe (assoc 'column err))
+                                      'error
+                                      (cdr-safe (assoc 'message err))
+                                      :checker checker
+                                      :buffer buffer
+                                      :filename (cdr-safe (assoc 'file err))))))
+     (json-read-from-string output))))
 
 (add-to-list 'flycheck-checkers 'crystal-build)
 

--- a/flycheck-crystal.el
+++ b/flycheck-crystal.el
@@ -75,8 +75,8 @@ default-directory))
 (defun flycheck-crystal--error-parser (output checker buffer)
   (mapcan
    (lambda (err)
-     (unless (or flycheck-crystal-show-instantiating
-                 (string-prefix-p "instantiating" (cdr-safe (assoc 'message err))))
+     (when (or flycheck-crystal-show-instantiating
+               (not (string-prefix-p "instantiating" (cdr-safe (assoc 'message err)))))
        (list (flycheck-error-new-at (cdr-safe (assoc 'line err))
                                     (cdr-safe (assoc 'column err))
                                     'error


### PR DESCRIPTION
If this variable is non-nil, all reported error messages (including
`instantiating`) are shown. The former code incorrectly suppresses *all* errors
if this variable is non-nil.