### PR TITLE
Pass flycheck crystal-build source in using stdin

### DIFF
--- a/flycheck-crystal.el
+++ b/flycheck-crystal.el
@@ -57,7 +57,7 @@ of the current file."
    (and
     buffer-file-name
     (locate-dominating-file buffer-file-name "shard.yml"))
-default-directory))
+   default-directory))
 
 (flycheck-define-checker crystal-build
   "A Crystal syntax checker using crystal build"
@@ -66,10 +66,12 @@ default-directory))
             "--no-codegen"
             "--no-color"
             "-f" "json"
-            source-inplace)
+            "--stdin-filename"
+            (eval (buffer-file-name)))
   :working-directory flycheck-crystal--find-default-directory
   :error-parser flycheck-crystal--error-parser
   :modes crystal-mode
+  :standard-input t
   )
 
 (defun flycheck-crystal--error-parser (output checker buffer)


### PR DESCRIPTION
This avoids creating a new file in the directory every time flycheck runs.

I've tested this locally, and I'm sure this works, would be nice to have someone merge this.

I used to be a crystal-lang-tools member too, but I left when I left the core team, and I probably shouldn't have considering I'm happy to review PRs here.