### PR TITLE
Fixes fun definitions to not expect an end-keyword.

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -440,6 +440,11 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
 
          (dot-stmt (stmt) (stmt "." dot-stmt))
 
+         (type (id)
+               (type "::" id))
+
+         (type-spec (":" type))
+
          (stmt ("def" stmts-rescue-stmts "end")
                ("begin" stmts-rescue-stmts "end")
                ("do" stmts-rescue-stmts "end")
@@ -449,7 +454,7 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
                ;; c-binding
                ("lib" stmts"end")
                ("struct" stmts "end")
-               ("fun" stmts "end")
+               ("fun" id "(" stmts ")" type-spec)
                ("enum" stmts "end")
                ("union" stmts "end")
                ;; control exp


### PR DESCRIPTION
Changes so that blocks like 
```
lib Foo
  fun foo(entries : LibC::UInt) : LibC::Int
  fun bar(entries : LibC::UInt) : LibC::Int
end
```
is indented correctly.

Unfortunatly does not handle pointers, so 

```
lib Foo
  fun foo(entries : LibC::UInt) : LibC::Int*
  fun bar(entries : LibC::UInt) : LibC::Int
end
```
will still not indent correctly. Anyone knows how to handle that case? The variants I tried just gave a reduce conflict. I'd still like to merge without that, as there is still a fairly big improvement.