### PR TITLE
add outline-regexp to allow for folding using outline-minor-mode

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -1021,7 +1021,8 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
   (setq-local parse-sexp-lookup-properties t)
   (setq-local paragraph-start (concat "$\\|" page-delimiter))
   (setq-local paragraph-separate paragraph-start)
-  (setq-local paragraph-ignore-fill-prefix t))
+  (setq-local paragraph-ignore-fill-prefix t)
+  (setq-local outline-regexp crystal-indent-beg-re))
 
 (defun crystal--insert-coding-comment (encoding)
   "Insert a magic coding comment for ENCODING.


### PR DESCRIPTION
Emacs programming language modes outline-regexp to allow for folding and outlining of code. Since this feature is handy to have it is good to have this variable set. Especially for those that use outline-minor-mode frequently.