### PR TITLE
Add to auto-mode-alist the canonical way

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -2784,10 +2784,7 @@ directory of the current file."
 ;;; Invoke crystal-mode when appropriate
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist
-             (cons (purecopy (concat "\\(?:\\."
-                                     "cr"
-                                     "\\)\\'")) 'crystal-mode))
+(add-to-list 'auto-mode-alist '("\\.cr\\'" . 'crystal-mode))
 
 ;;;###autoload
 (dolist (name (list "crystal"))


### PR DESCRIPTION
The add-to-list was a bit crafty due to being based on a complicated regex in the original ruby-mode.

Ended up looking at it because I was thinking of opening `.ecr` files in `html-mode`, but then it dawned on me that ECR could template many other things too, so I dropped the idea again. But this cleanup still applies.