### PR TITLE
Fix error: (wrong-number-of-arguments #<subr quote> 0)

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -2784,7 +2784,7 @@ directory of the current file."
 ;;; Invoke crystal-mode when appropriate
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.cr\\'" . 'crystal-mode))
+(add-to-list 'auto-mode-alist (cons (purecopy"\\(?:\\.cr\\)\\'") 'crystal-mode))
 
 ;;;###autoload
 (dolist (name (list "crystal"))


### PR DESCRIPTION
Fixes an error introduced with pr #55 while still cleaning up the `ADD-TO-ALIST` CALL.