### PR TITLE
Enable editing files with syntax errors having a "%}" without matching "{%".

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -701,17 +701,17 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
      ((looking-back "%}" (line-beginning-position))
       (let ((macro-prefix "{%")
             (macro-suffix "%}"))
-        (re-search-backward "{%")
-        (when (eq ?\\ (char-before))
-          (setq macro-prefix "\{%"))
-        (save-excursion
-          (forward-char 2)
-          (skip-chars-forward " \t")
-          (let ((tok (smie-default-forward-token)))
-            (if (member tok '("if" "else" "elsif" "end"
-                              "unless" "for" "while" "begin"))
-                (concat macro-prefix tok macro-suffix)
-              ";")))))
+        (when (re-search-backward "{%" nil t)
+          (when (eq ?\\ (char-before))
+            (setq macro-prefix "\{%"))
+          (save-excursion
+            (forward-char 2)
+            (skip-chars-forward " \t")
+            (let ((tok (smie-default-forward-token)))
+              (if (member tok '("if" "else" "elsif" "end"
+                                "unless" "for" "while" "begin"))
+                  (concat macro-prefix tok macro-suffix)
+                ";"))))))
 
      ((and (> pos (line-end-position))
            (crystal-smie--implicit-semi-p))


### PR DESCRIPTION
Second attempt to fix the problem described in #52. Though suppressing the error at top-level seems to fix it, the underlying problem is that the code currently assumes that there will be always a matching `{%` for every `%}`. In well-formed programs, this should hold but not if you are editing a file that would not compile. This PR tries to gracefully handle the missing match.

Example (it has a syntax error, but still it should allow to change "bar"):

```
%{ if flag?(:foo) %}
  bar
%{ end %}
```

Fixes #52