### PR TITLE
Adjust Tokenization to Better Support Crystal Macros

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -628,8 +628,12 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
       (forward-char 2)
       (skip-chars-forward " \t")
       (let ((tok (smie-default-forward-token)))
-        (if (member tok '("end" "else" "elsif"))
+        (if (member tok '("end" "else" "elsif" "if" "unless" "for" "while" "begin"))
             (concat "{%" tok "%}")
+          ;; For other macro content (assignments, expressions, etc.),
+          ;; skip to the closing %} and treat as statement separator
+          (when (re-search-forward "%}" (line-end-position) t)
+            (skip-chars-forward " \t"))
           ";")))
 
      ((and (looking-at "\n") (looking-at "\\s\""))  ;A heredoc.
@@ -2155,6 +2159,12 @@ It will be properly highlighted even when the call omits parens.")
        (0 (ignore (crystal-syntax-propertize-expansion))))
       ("^=en\\(d\\)\\_>" (1 "!"))
       ("^\\(=\\)begin\\_>" (1 "!"))
+      ;; Handle macro delimiters {%, %} - mark braces as punctuation
+      ;; so they don't interfere with block matching
+      ("\\({\\)%"
+       (1 (string-to-syntax ".")))
+      ("%\\(}\\)"
+       (1 (string-to-syntax ".")))
       ;; Handle here documents.
       ((concat crystal-here-doc-beg-re ".*\\(\n\\)")
        (7 (unless (or (nth 8 (save-excursion


### PR DESCRIPTION
This package has problems with the following Crystal syntax:

```crystal
  macro public_post(index, factory)
    {% if factory == :create %}
      let_build(:object, named: post{{index}}, attributed_to: actor)
      let_build(:create, named: activity{{index}}, actor: actor, object: post{{index}})
    {% elsif factory == :announce %}
      let_build(:actor, named: actor{{index}})
      let_build(:object, named: post{{index}}, attributed_to: actor{{index}})
      let_build(:announce, named: activity{{index}}, actor: actor, object: post{{index}})
    {% elsif factory == :like %}
      let_build(:actor, named: actor{{index}})
      let_build(:object, named: post{{index}}, attributed_to: actor{{index}})
      let_build(:like, named: activity{{index}}, actor: actor, object: post{{index}})
    {% end %}
    before_each { put_in_outbox(actor, activity{{index}}) }
  end
```
Specifically, it does not seem to handle macro control flow within `macro`. This PR makes some small adjustments to better support that syntax.

Additional, I am using this with hs-minor-mode and am running into problems with folding macros.
